### PR TITLE
Pin python, biopython

### DIFF
--- a/recipes/crispector2/meta.yaml
+++ b/recipes/crispector2/meta.yaml
@@ -19,11 +19,11 @@ source:
 
 requirements:
   host:
-    - python 3.7
+    - python >=3.8
     - pip
   run:
-    - python 3.7
-    - biopython >=1.74
+    - python >=3.8
+    - biopython >=1.74, <=1.79 # Bio.SubsMat
     - fastp
     - python-edlib
     - click >=7.0


### PR DESCRIPTION
Hello, I've made a few changes to troubleshoot the recipe; local build works for me

This fixes the following import problems by pinning python and biopython versions:
 * typing.Protocol introduced in python 3.8
 * Bio.SubsMat removed in biopython 1.80
